### PR TITLE
Fix shuffler never moving the first song in the queue

### DIFF
--- a/src/commands/music/shuffle.js
+++ b/src/commands/music/shuffle.js
@@ -10,7 +10,7 @@ module.exports = {
         const player = message.client.manager.get(message.guild.id);
         let songs = player.queue;
 
-        for (let i = songs.length - 1; i > 1; i--) {
+        for (let i = songs.length - 1; i > 0; i--) {
             let j = 1 + Math.floor(Math.random() * i);
             [songs[i], songs[j]] = [songs[j], songs[i]];
         }


### PR DESCRIPTION
The shuffler currently never moves the song at position 1 in the queue. This is annoying. This PR fixes the off by one defect in the shuffler so it properly shuffles every song into a new spot in the queue, instead of shuffling every song except for the first one.

Vid showing bug: https://www.youtube.com/watch?v=ug9ZBd_gW58

